### PR TITLE
Update plugin.py

### DIFF
--- a/python/Plugins/Extensions/WeatherMSN/plugin.py
+++ b/python/Plugins/Extensions/WeatherMSN/plugin.py
@@ -39,7 +39,7 @@ from Components.config import getConfigListEntry, ConfigText, ConfigYesNo, Confi
 from Components.Pixmap import Pixmap
 from Tools.Directories import fileExists, resolveFilename, SCOPE_PLUGINS, SCOPE_LANGUAGE
 from xml.etree.cElementTree import fromstring as cet_fromstring
-from urllib2 import urlopen, Request, URLError, HTTPError
+from urllib2 import urlopen, Request, URLError, HTTPError, quote
 from twisted.web.client import downloadPage
 from time import localtime, strftime
 from enigma import eTimer, ePoint
@@ -663,7 +663,7 @@ class WeatherMSN(ConfigListScreen, Screen):
 
 	def get_xmlfile(self):
 #		xmlfile = "http://weather.service.msn.com/data.aspx?weadegreetype=C&culture=ru-RU&weasearchstr=Moscow,Moscow-City,Russia&src=outlook"
-		xmlfile = "http://weather.service.msn.com/data.aspx?weadegreetype=%s&culture=%s&weasearchstr=%s&src=outlook" % (self.degreetype, self.language, self.city)
+		xmlfile = "http://weather.service.msn.com/data.aspx?weadegreetype=%s&culture=%s&weasearchstr=%s&src=outlook" % (self.degreetype, self.language, quote(self.city))
 		downloadPage(xmlfile, "/tmp/weathermsn1.xml").addCallback(self.downloadFinished).addErrback(self.downloadFailed)
 
 	def downloadFinished(self, result):


### PR DESCRIPTION
Newer twisted seems to have issues with Unicode characters (eg Sliač).

Using function quote from urllib2 seems to fix the issue.

Here is the traceback produced without quote function.

Traceback (most recent call last):
  File "/usr/lib/enigma2/python/mytest.py", line 209, in processDelay
    self.popCurrent()
  File "/usr/lib/enigma2/python/mytest.py", line 278, in popCurrent
    self.execBegin(first=False, do_show=do_show)
  File "/usr/lib/enigma2/python/mytest.py", line 228, in execBegin
    c.show()
  File "/usr/lib/enigma2/python/Screens/Screen.py", line 150, in show
  File "/usr/lib/enigma2/python/plugin.py", line 322, in get_weather_data
  File "/usr/lib/enigma2/python/plugin.py", line 318, in get_xmlfile
  File "/usr/lib/python2.7/site-packages/twisted/python/deprecate.py", line 301, in deprecatedFunction
  File "/usr/lib/python2.7/site-packages/twisted/web/client.py", line 814, in downloadPage
  File "/usr/lib/python2.7/site-packages/twisted/web/client.py", line 742, in _makeGetterFactory
  File "/usr/lib/python2.7/site-packages/twisted/web/_newclient.py", line 648, in _ensureValidURI
ValueError: Invalid URI 'http://weather.service.msn.com/data.aspx?weadegreetype=C&culture=sk-SK&weasearchstr=Slia\xc4\x8d&src=outlook'